### PR TITLE
fixes minor typo

### DIFF
--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -544,7 +544,7 @@
 			</trans-unit>
 			<trans-unit id="email_user_activate_message" xml:space="preserve" approved="yes">
 				<source>please activate your account %1$s</source>
-				<target>bitte aktivierren Sie Ihren Account %1$s</target>
+				<target>bitte aktivieren Sie Ihren Account %1$s</target>
 			</trans-unit>
 			<trans-unit id="email_user_activate_link" xml:space="preserve" approved="yes">
 				<source>activate your account</source>


### PR DESCRIPTION
the german translation of **email_admin_activate_message**: (**aktivierren**) should be : bitte **aktivieren** Sie den Account.